### PR TITLE
Please pull, allowing single quotes in content matchers

### DIFF
--- a/lib/rspec/rails/views/matchers/have_tag.rb
+++ b/lib/rspec/rails/views/matchers/have_tag.rb
@@ -104,9 +104,11 @@ module RSpec
 	    false
 	  end
 	else
-	  new_scope = @current_scope.css(":content('#{text}')",Class.new {
+    css_param = text.gsub(/'/) { %q{\000027} }
+    new_scope = @current_scope.css(":content('#{css_param}')",Class.new {
 	    def content node_set, text
-	      node_set.find_all { |node| node.content == text }
+        match_text = text.gsub(/\\000027/, "'")
+	      node_set.find_all { |node| node.content == match_text }
 	    end
 	  }.new)
 	  unless new_scope.empty?

--- a/spec/matchers/have_tag_spec.rb
+++ b/spec/matchers/have_tag_spec.rb
@@ -178,6 +178,7 @@ HTML
     before :each do
       render_html <<HTML
 <div>sample text</div>
+<span>sample with 'single' quotes</span>
 <p>one </p>
 <p> two</p>
 <p> three </p>
@@ -185,9 +186,10 @@ HTML
     end
 
     it "should find tags" do
-      rendered.should have_tag('div', :text => 'sample text')
-      rendered.should have_tag('p',   :text => 'one '       )
-      rendered.should have_tag('div', :text => /SAMPLE/i    )
+      rendered.should have_tag('div',  :text => 'sample text'                )
+      rendered.should have_tag('p',    :text => 'one '                       )
+      rendered.should have_tag('div',  :text => /SAMPLE/i                    )
+      rendered.should have_tag('span', :text => "sample with 'single' quotes")
     end
 
     it "should not find tags" do


### PR DESCRIPTION
I needed to match on something that had a single quote in the content.

I added a spec and a fix. 

-Kelly
