### PR TITLE
Backward compatibility for have_tag with String argument

### DIFF
--- a/lib/rspec2-rails-views-matchers.rb
+++ b/lib/rspec2-rails-views-matchers.rb
@@ -207,6 +207,9 @@ module RSpec
     #   '<div class="one two">'.should have_tag('div', :with => { :class => ['two', 'one'] })
     #   '<div class="one two">'.should have_tag('div', :with => { :class => 'two one' })
     def have_tag tag, options={}, &block
+      if options.kind_of? String
+        options = { :text => options }
+      end
       @__current_scope_for_nokogiri_matcher = NokogiriMatcher.new(tag, options, &block)
     end
 

--- a/spec/matchers/have_tag_spec.rb
+++ b/spec/matchers/have_tag_spec.rb
@@ -205,6 +205,10 @@ describe 'have_tag' do
       rendered.should have_tag('pre',  :text => " 1. bla   \n 2. bla ")
     end
 
+    it "should map a string argument to :text => string" do
+      rendered.should have_tag('div',  'sample text')
+    end
+
     it "should not find tags" do
       rendered.should_not have_tag('p',      :text => 'text does not present')
       rendered.should_not have_tag('strong', :text => 'text does not present')


### PR DESCRIPTION
In previous version of Rspec, the following syntax is supported:
with_tag "div", "sample text"

This pull request will provide the same functionality as above.
