### PR TITLE
Fix for content matching regexs with single + double quotes

### DIFF
--- a/lib/rspec-html-matchers.rb
+++ b/lib/rspec-html-matchers.rb
@@ -121,11 +121,15 @@ module RSpec
 
         case text=@options[:text]
         when Regexp
-          new_scope = @current_scope.css(":regexp('#{text}')",Class.new {
-            def regexp node_set, text
-              node_set.find_all { |node| node.content =~ Regexp.new(text) }
+          new_scope = @current_scope.css(":regexp()",Class.new {
+            def initialize(regex)
+              @regex = regex
             end
-          }.new)
+
+            def regexp node_set
+              node_set.find_all { |node| node.content =~ @regex }
+            end
+          }.new(text))
           unless new_scope.empty?
             @count = new_scope.count
             @negative_failure_message = REGEXP_FOUND_MSG % [text.inspect,@tag,@document]

--- a/spec/matchers/have_tag_spec.rb
+++ b/spec/matchers/have_tag_spec.rb
@@ -211,6 +211,7 @@ describe 'have_tag' do
       rendered.should have_tag('div',  :text => /SAMPLE/i)
       rendered.should have_tag('span', :text => "sample with 'single' quotes")
       rendered.should have_tag('span', :text => %Q{sample with 'single' and "double" quotes})
+      rendered.should have_tag('span', :text => /sample with 'single' and "double" quotes/)
 
       rendered.should have_tag('p',    :text => 'content with ignored spaces around')
       rendered.should have_tag('p',    :text => 'content with ignored spaces in')
@@ -267,7 +268,6 @@ describe 'have_tag' do
         %Q{/SAMPLE text/i regexp unexpected within "div" in following template:\n#{rendered}\nbut was found.}
       )
     end
-
   end
 
   context "mixed matching" do


### PR DESCRIPTION
Currently when trying to use single quotes in a regular expression to match tag content, a `Nokogiri::CSS::SyntaxError` error occurs because of the syntax used for the `regex` custom CSS pseudo class.
