### PR TITLE
Allow using matchers on nokogiri xml documents

### DIFF
--- a/lib/rspec-html-matchers.rb
+++ b/lib/rspec-html-matchers.rb
@@ -98,10 +98,13 @@ module RSpec
         when String
           @parent_scope = @current_scope = Nokogiri::HTML(document).css(@tag)
           @document     = document
-        else
+        when self.class
           @parent_scope  = document.current_scope
           @current_scope = document.parent_scope.css(@tag)
           @document      = @parent_scope.to_html
+        else
+          @parent_scope = @current_scope = document.search(@tag)
+          @document = document
         end
 
         if tag_presents? and text_right? and count_right?

--- a/spec/matchers/have_tag_spec.rb
+++ b/spec/matchers/have_tag_spec.rb
@@ -485,4 +485,10 @@ describe 'have_tag' do
       }.to raise_spec_error(/\/SAMPLE text\/i regexp expected within "li" in following template:\n#{ordered_list_regexp}/)
     end
   end
+
+  context "xml document" do
+    subject(:xml) { Nokogiri::XML('<root><node/></root>') }
+    it('should match root') { should have_tag('root') }
+    its('root') { should have_tag('node') }
+  end
 end


### PR DESCRIPTION
Hi there!

I wanted to use these awesome helpers to match some generated XML documents, but unfortunately it was expecting just string or nesting.
So I made a patch with tests to support calling these matchers on `Nokogiri::XML::Document` or any object implementing `search`.
