### PR TITLE
Test for Capybara::Session definition, rather than Capybara

### DIFF
--- a/lib/rspec-html-matchers.rb
+++ b/lib/rspec-html-matchers.rb
@@ -94,7 +94,7 @@ module RSpec
       def matches? document, &block
         @block = block if block
 
-        document = document.html if defined?(Capybara) && document.is_a?(Capybara::Session)
+        document = document.html if defined?(Capybara::Session) && document.is_a?(Capybara::Session)
 
         case document
         when String


### PR DESCRIPTION
...as Capybara can be defined even when Capbybara::Session is not, in which case we get:

```
NameError:
      uninitialized constant Capybara::Session
      /rspec-html-matchers-0.4.3/lib/rspec-html-matchers.rb:97:in `matches?'
```
