### PR TITLE
Fixes initialization code if cucumber and rspec are used in parallel

### DIFF
--- a/lib/rspec-html-matchers.rb
+++ b/lib/rspec-html-matchers.rb
@@ -560,9 +560,14 @@ module RSpec
   end
 end
 
-if defined? Cucumber
-  World RSpec::HtmlMatchers
-else
+
+begin
+  defined? Cucumber and World RSpec::HtmlMatchers
+rescue NoMethodError
+  # started rspec, but Cucumber is also a known constant
+end
+
+if defined? RSpec
   RSpec.configure do |config|
     config.include(RSpec::HtmlMatchers)
   end


### PR DESCRIPTION
Hello!

We use cucumber as well as rspec for our test suite. But I was not able to use this gem because of the initialization code you use [here](https://github.com/kucaahbe/rspec-html-matchers/blob/master/lib/rspec-html-matchers.rb#L564). So starting rspecs I get the following error `gems/rspec-html-matchers-0.6.1/lib/rspec-html-matchers.rb:564:in  <top (required)>': undefined method 'World' for main:Object (NoMethodError)`.
So, in order to get it working I had to set `gem 'rspec-html-matchers', require: false` in my `Gemfile` and do the following in my `rails_helper.rb`:
```ruby
def World(*); end
require 'rspec-html-matchers'
config.include RSpec::HtmlMatchers
```
And this code is really dirty!
I am not a big fan of doing everything automatically and would rather include html matchers explicitly. But in order to not break the running code of users using this library I just rescued from the `NoMethodError` in my pull request.

Thank you.

Andreas