### PR TITLE
Upgrade rspec version to 3.3

### DIFF
--- a/rspec-html-matchers.gemspec
+++ b/rspec-html-matchers.gemspec
@@ -22,7 +22,7 @@ DESC
   s.extra_rdoc_files = ['README.md','CHANGELOG.md']
 
   # since 2.11.0 introduced new expect().to syntax
-  s.add_runtime_dependency 'rspec',    '~> 3'
+  s.add_runtime_dependency 'rspec',    '~> 3.3.0'
   s.add_runtime_dependency 'nokogiri', '~> 1'
 
   s.add_development_dependency 'simplecov',          '~> 0'


### PR DESCRIPTION
http://rspec.info/blog/2015/06/rspec-3-3-has-been-released/

The tests are passing. Rspec 3.3 has pretty cool features such as `--bisect` - this will allow rspec-html-matchers users to take advantage of those.