### PR TITLE
adds have_empty_tag matcher

### DIFF
--- a/lib/rspec-html-matchers.rb
+++ b/lib/rspec-html-matchers.rb
@@ -275,6 +275,10 @@ module RSpecHtmlMatchers
     @__current_scope_for_nokogiri_matcher = HaveTag.new(tag, options, &block)
   end
 
+  def have_empty_tag tag, options={}
+    have_tag(tag, options.merge(text: ""))
+  end
+
   def with_text text
     raise StandardError, 'this matcher should be used inside "have_tag" matcher block' unless defined?(@__current_scope_for_nokogiri_matcher)
     raise ArgumentError, 'this matcher does not accept block' if block_given?

--- a/spec/have_empty_tag_spec.rb
+++ b/spec/have_empty_tag_spec.rb
@@ -1,0 +1,29 @@
+# encoding: UTF-8
+require 'spec_helper'
+
+describe 'have_empty_tag' do
+  context 'when single element' do
+    asset 'single_element'
+
+    it { expect(rendered).to have_empty_tag('div') }
+    it { expect(rendered).to have_empty_tag('div', class: "foo") }
+    it { expect(rendered).to have_empty_tag('div', class: "bar") }
+    it { expect(rendered).to have_empty_tag('div', class: "foo bar") }
+  end
+
+  context 'when paragraphs' do
+    asset 'paragraphs'
+
+    it { expect(rendered).to_not have_empty_tag('p') }
+  end
+
+  context 'when ordered list' do
+    asset 'ordered_list'
+
+    it { expect(rendered).to_not have_empty_tag('html') }
+    it { expect(rendered).to_not have_empty_tag('body') }
+    it { expect(rendered).to_not have_empty_tag('ol') }
+    it { expect(rendered).to_not have_empty_tag('ol', class: 'menu') }
+    it { expect(rendered).to_not have_empty_tag('li') }
+  end
+end


### PR DESCRIPTION
This PR is suppose to add `have_empty_tag` matcher to the list of possible matchers. 