### PR TITLE
Fix frozen string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 unreleased(TODO)
 ----------------
 
+* add support for `frozen_string_literals`
 * with_tag should raise error when used outside have_tag
 * add ability to have_form('/url', 'PUT') or have_form('/url', :PUT)
 * inteligent check comments(make sure it is not searching inside comments)

--- a/lib/rspec-html-matchers.rb
+++ b/lib/rspec-html-matchers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'rspec'
 require 'nokogiri'
@@ -79,18 +80,18 @@ module RSpecHtmlMatchers
 
       if with_attrs = @options.delete(:with)
         if classes = with_attrs.delete(:class)
-          @tag << '.' + classes_to_selector(classes)
+          @tag += '.' + classes_to_selector(classes)
         end
         selector = with_attrs.inject('') do |html_attrs_string, (k, v)|
-          html_attrs_string << "[#{k}='#{v}']"
+          html_attrs_string += "[#{k}='#{v}']"
         html_attrs_string
         end
-        @tag << selector
+        @tag += selector
       end
 
       if without_attrs = @options.delete(:without)
         if classes = without_attrs.delete(:class)
-          @tag << ":not(.#{classes_to_selector(classes)})"
+          @tag += ":not(.#{classes_to_selector(classes)})"
         end
       end
 
@@ -319,7 +320,7 @@ module RSpecHtmlMatchers
   def have_form action_url, method, options={}, &block
     options[:with] ||= {}
     id = options[:with].delete(:id)
-    tag = 'form'; tag << '#'+id if id
+    tag = 'form'; tag += '#'+id if id
     options[:with].merge!(:action => action_url)
     options[:with].merge!(:method => method.to_s)
     have_tag tag, options, &block
@@ -463,7 +464,7 @@ module RSpecHtmlMatchers
   def with_select name, options={}, &block
     options[:with] ||= {}
     id = options[:with].delete(:id)
-    tag='select'; tag << '#'+id if id
+    tag='select'; tag += '#'+id if id
     options[:with].merge!(:name => name)
     expect(@__current_scope_for_nokogiri_matcher).to have_tag(tag, options, &block)
   end
@@ -471,7 +472,7 @@ module RSpecHtmlMatchers
   def without_select name, options={}, &block
     options[:with] ||= {}
     id = options[:with].delete(:id)
-    tag='select'; tag << '#'+id if id
+    tag='select'; tag += '#'+id if id
     options[:with].merge!(:name => name)
     expect(@__current_scope_for_nokogiri_matcher).to_not have_tag(tag, options, &block)
   end


### PR DESCRIPTION
This PR adds support for the Ruby 2.3.0 magic comment `# frozen_string_literal: true`, which is proposed as default in Ruby 3.

This means string concatenation with `<<` is not allowed anymore.