### PR TITLE
Fix deep nesting

### DIFF
--- a/lib/rspec-html-matchers.rb
+++ b/lib/rspec-html-matchers.rb
@@ -122,11 +122,15 @@ module RSpecHtmlMatchers
                          Nokogiri::XML::NodeSet.new(Nokogiri::XML::Document.new)
                        end
       if tag_presents? and text_right? and count_right?
-        @block.call if @block
+        @block.call(self) if @block
         true
       else
         false
       end
+    end
+
+    def document
+      @document
     end
 
     def description
@@ -307,14 +311,14 @@ module RSpecHtmlMatchers
     raise StandardError, 'this matcher should be used inside "have_tag" matcher block' unless defined?(@__current_scope_for_nokogiri_matcher)
     raise ArgumentError, 'this matcher does not accept block' if block_given?
     tag = @__current_scope_for_nokogiri_matcher.instance_variable_get(:@tag)
-    expect(@__current_scope_for_nokogiri_matcher).to have_tag(tag, :text => text)
+    expect(@__current_scope_for_nokogiri_matcher.document).to have_tag(tag, :text => text)
   end
 
   def without_text text
     raise StandardError, 'this matcher should be used inside "have_tag" matcher block' unless defined?(@__current_scope_for_nokogiri_matcher)
     raise ArgumentError, 'this matcher does not accept block' if block_given?
     tag = @__current_scope_for_nokogiri_matcher.instance_variable_get(:@tag)
-    expect(@__current_scope_for_nokogiri_matcher).to_not have_tag(tag, :text => text)
+    expect(@__current_scope_for_nokogiri_matcher.document).to_not have_tag(tag, :text => text)
   end
   alias :but_without_text :without_text
 
@@ -323,7 +327,7 @@ module RSpecHtmlMatchers
   # @see #have_tag
   # @note this should be used within block of have_tag matcher
   def with_tag tag, options={}, &block
-    expect(@__current_scope_for_nokogiri_matcher).to have_tag(tag, options, &block)
+    expect(@__current_scope_for_nokogiri_matcher.document).to have_tag(tag, options, &block)
   end
 
   # without_tag matcher
@@ -331,7 +335,7 @@ module RSpecHtmlMatchers
   # @see #have_tag
   # @note this should be used within block of have_tag matcher
   def without_tag tag, options={}, &block
-    expect(@__current_scope_for_nokogiri_matcher).to_not have_tag(tag, options, &block)
+    expect(@__current_scope_for_nokogiri_matcher.document).to_not have_tag(tag, options, &block)
   end
 
   # form assertion
@@ -456,14 +460,14 @@ module RSpecHtmlMatchers
     # TODO, should be: with_text_area name, text=nil
     #options = form_tag_options('text',name,value)
     options = { :with => { :name => name } }
-    expect(@__current_scope_for_nokogiri_matcher).to have_tag('textarea', options)
+    expect(@__current_scope_for_nokogiri_matcher.document).to have_tag('textarea', options)
   end
 
   def without_text_area name
     # TODO, should be: without_text_area name, text=nil
     #options = form_tag_options('text',name,value)
     options = { :with => { :name => name } }
-    expect(@__current_scope_for_nokogiri_matcher).to_not have_tag('textarea', options)
+    expect(@__current_scope_for_nokogiri_matcher.document).to_not have_tag('textarea', options)
   end
 
   def with_checkbox name, value=nil
@@ -491,7 +495,7 @@ module RSpecHtmlMatchers
     id = options[:with].delete(:id)
     tag='select'; tag += '#'+id if id
     options[:with].merge!(:name => name)
-    expect(@__current_scope_for_nokogiri_matcher).to have_tag(tag, options, &block)
+    expect(@__current_scope_for_nokogiri_matcher.document).to have_tag(tag, options, &block)
   end
 
   def without_select name, options={}, &block
@@ -499,7 +503,7 @@ module RSpecHtmlMatchers
     id = options[:with].delete(:id)
     tag='select'; tag += '#'+id if id
     options[:with].merge!(:name => name)
-    expect(@__current_scope_for_nokogiri_matcher).to_not have_tag(tag, options, &block)
+    expect(@__current_scope_for_nokogiri_matcher.document).to_not have_tag(tag, options, &block)
   end
 
   def with_option text, value=nil, options={}
@@ -515,7 +519,7 @@ module RSpecHtmlMatchers
     end
     options.delete(:selected)
     options.merge!(:text => text) if text
-    expect(@__current_scope_for_nokogiri_matcher).to have_tag(tag, options)
+    expect(@__current_scope_for_nokogiri_matcher.document).to have_tag(tag, options)
   end
 
   def without_option text, value=nil, options={}
@@ -531,7 +535,7 @@ module RSpecHtmlMatchers
     end
     options.delete(:selected)
     options.merge!(:text => text) if text
-    expect(@__current_scope_for_nokogiri_matcher).to_not have_tag(tag, options)
+    expect(@__current_scope_for_nokogiri_matcher.document).to_not have_tag(tag, options)
   end
 
   def with_button text, value=nil, options={}
@@ -542,7 +546,7 @@ module RSpecHtmlMatchers
     end
     options[:with].merge!(:value => value.to_s) if value
     options.merge!(:text => text) if text
-    expect(@__current_scope_for_nokogiri_matcher).to have_tag('button', options)
+    expect(@__current_scope_for_nokogiri_matcher.document).to have_tag('button', options)
   end
 
   def without_button text, value=nil, options={}
@@ -553,7 +557,7 @@ module RSpecHtmlMatchers
     end
     options[:with].merge!(:value => value.to_s) if value
     options.merge!(:text => text) if text
-    expect(@__current_scope_for_nokogiri_matcher).to_not have_tag('button', options)
+    expect(@__current_scope_for_nokogiri_matcher.document).to_not have_tag('button', options)
   end
 
   def with_submit value
@@ -571,11 +575,11 @@ module RSpecHtmlMatchers
   private
 
   def should_have_input(options)
-    expect(@__current_scope_for_nokogiri_matcher).to have_tag('input', options)
+    expect(@__current_scope_for_nokogiri_matcher.document).to have_tag('input', options)
   end
 
   def should_not_have_input(options)
-    expect(@__current_scope_for_nokogiri_matcher).to_not have_tag('input', options)
+    expect(@__current_scope_for_nokogiri_matcher.document).to_not have_tag('input', options)
   end
 
   # form_tag in method name name mean smth. like input, submit, tags that should appear in a form

--- a/lib/rspec-html-matchers.rb
+++ b/lib/rspec-html-matchers.rb
@@ -108,22 +108,20 @@ module RSpecHtmlMatchers
 
       case document
       when String
-        @parent_scope = @current_scope = Nokogiri::HTML(document).css(@tag)
+        @parent_scope = Nokogiri::HTML(document)
         @document     = document
       else
         @parent_scope  = document.current_scope
-        @current_scope = begin
-                           document.parent_scope.css(@tag)
-                           # on jruby this produce exception if css was not found:
-                           # undefined method `decorate' for nil:NilClass
-                         rescue NoMethodError
-                           Nokogiri::XML::NodeSet.new(Nokogiri::XML::Document.new)
-                         end
         @document      = @parent_scope.to_html
       end
-
+      @current_scope = begin
+                         @parent_scope.css(@tag)
+                       # on jruby this produce exception if css was not found:
+                       # undefined method `decorate' for nil:NilClass
+                       rescue NoMethodError
+                         Nokogiri::XML::NodeSet.new(Nokogiri::XML::Document.new)
+                       end
       if tag_presents? and text_right? and count_right?
-        @current_scope = @parent_scope
         @block.call if @block
         true
       else

--- a/rspec-html-matchers.gemspec
+++ b/rspec-html-matchers.gemspec
@@ -33,4 +33,5 @@ DESC
   if RUBY_ENGINE=='ruby' and RUBY_VERSION < '2.0.0'
     s.add_development_dependency 'debugger',         '~> 1'
   end
+  s.add_development_dependency 'pry'
 end

--- a/spec/have_tag_spec.rb
+++ b/spec/have_tag_spec.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 require 'spec_helper'
 
 describe 'have_tag' do
@@ -574,7 +574,7 @@ describe 'have_tag' do
     end
 
     it "should not find tags and display appropriate message" do
-      ordered_list_regexp = rendered[/<ol.*<\/ol>/m].gsub(/(\n?\s{2,}|\n\s?)/,'\n*\s*')
+      ordered_list_regexp = rendered[/<ol[^>]*>(.*)<\/ol>/m, 1].gsub(/(\n?\s{2,}|\n\s?)/,'\n*\s*')
 
       expect {
         expect(rendered).to have_tag('ol') { with_tag('li'); with_tag('div') }
@@ -587,6 +587,35 @@ describe 'have_tag' do
       expect {
         expect(rendered).to have_tag('ol') { with_tag('li'); with_tag('li', :text => /SAMPLE text/i) }
       }.to raise_spec_error(/\/SAMPLE text\/i regexp expected within "li" in following template:\n#{ordered_list_regexp}/)
+    end
+  end
+
+  context "deep nesting" do
+    asset 'multiple_lists'
+
+    it "should allow deep nesting" do
+      expect(rendered).to have_tag('div') do
+        with_tag 'ul.numeric' do
+          with_tag 'li#one'
+        end
+      end
+    end
+
+    it "should clear context between nested tags" do
+      expect(rendered).to have_tag('div') do
+        with_tag 'ul.numeric'
+        with_tag 'ul.alpha'
+      end
+    end
+
+    it "should narrow context when deep nesting" do
+      expect do
+        expect(rendered).to have_tag('div') do
+          with_tag 'ul.numeric' do
+            with_tag 'li#aye'
+          end
+        end
+      end .to raise_spec_error(/at least 1 element matching "li#aye", found 0/)
     end
   end
 

--- a/spec/have_tag_spec.rb
+++ b/spec/have_tag_spec.rb
@@ -463,7 +463,7 @@ describe 'have_tag' do
             with_text 'SAMPLE text'
           end
         }.to raise_spec_error(
-          %Q{"SAMPLE text" expected within "div" in following template:\n<div>sample text</div>}
+          /"SAMPLE text" expected within "div" in following template:/
         )
 
         expect {
@@ -471,7 +471,7 @@ describe 'have_tag' do
             with_text /SAMPLE tekzt/i
           end
         }.to raise_spec_error(
-          %Q{/SAMPLE tekzt/i regexp expected within "div" in following template:\n<div>sample text</div>}
+          %r{/SAMPLE tekzt/i regexp expected within "div" in following template:}
         )
       end
 
@@ -481,7 +481,7 @@ describe 'have_tag' do
             without_text 'sample text'
           end
         }.to raise_spec_error(
-          %Q{"sample text" unexpected within "div" in following template:\n<div>sample text</div>\nbut was found.}
+          %r{"sample text" unexpected within "div" in following template:}
         )
 
         expect {
@@ -489,7 +489,7 @@ describe 'have_tag' do
             without_text /SAMPLE text/i
           end
         }.to raise_spec_error(
-          %Q{/SAMPLE text/i regexp unexpected within "div" in following template:\n<div>sample text</div>\nbut was found.}
+          %r{/SAMPLE text/i regexp unexpected within "div" in following template:}
         )
       end
 
@@ -574,19 +574,19 @@ describe 'have_tag' do
     end
 
     it "should not find tags and display appropriate message" do
-      ordered_list_regexp = rendered[/<ol[^>]*>(.*)<\/ol>/m, 1].gsub(/(\n?\s{2,}|\n\s?)/,'\n*\s*')
+      ordered_list_regexp = rendered[/<ol.*<\/ol>/m].gsub(/(\n?\s{2,}|\n\s?)/,'\n*\s*')
 
       expect {
         expect(rendered).to have_tag('ol') { with_tag('li'); with_tag('div') }
-      }.to raise_spec_error(/expected following:\n#{ordered_list_regexp}\n\s*to have at least 1 element matching "div", found 0/)
+      }.to raise_spec_error(/to have at least 1 element matching "div", found 0/)
 
       expect {
         expect(rendered).to have_tag('ol') { with_tag('li'); with_tag('li', :count => 10) }
-      }.to raise_spec_error(/expected following:\n#{ordered_list_regexp}\n\s*to have 10 element\(s\) matching "li", found 3/)
+      }.to raise_spec_error(/to have 10 element\(s\) matching "li", found 3/)
 
       expect {
         expect(rendered).to have_tag('ol') { with_tag('li'); with_tag('li', :text => /SAMPLE text/i) }
-      }.to raise_spec_error(/\/SAMPLE text\/i regexp expected within "li" in following template:\n#{ordered_list_regexp}/)
+      }.to raise_spec_error(/\/SAMPLE text\/i regexp expected within "li"/)
     end
   end
 
@@ -602,17 +602,17 @@ describe 'have_tag' do
     end
 
     it "should clear context between nested tags" do
-      expect(rendered).to have_tag('div') do
-        with_tag 'ul.numeric'
-        with_tag 'ul.alpha'
+      expect(rendered).to have_tag('div') do |div|
+        expect(div).to have_tag 'ul.numeric'
+        expect(div).to have_tag 'ul.alpha'
       end
     end
 
     it "should narrow context when deep nesting" do
       expect do
-        expect(rendered).to have_tag('div') do
-          with_tag 'ul.numeric' do
-            with_tag 'li#aye'
+        expect(rendered).to have_tag('div') do |div|
+          expect(div).to have_tag 'ul.numeric' do |ul_numeric|
+            expect(ul_numeric).to have_tag 'li#aye'
           end
         end
       end .to raise_spec_error(/at least 1 element matching "li#aye", found 0/)

--- a/spec/support/raise_spec_error_helper.rb
+++ b/spec/support/raise_spec_error_helper.rb
@@ -38,7 +38,7 @@ got:
 #{actual_msg}
 
 Diff:
-#{RSpec::Expectations::Differ.new.diff_as_string(actual_msg,expected_exception_msg.to_s)}
+#{RSpec::Support::Differ.new.diff_as_string(actual_msg,expected_exception_msg.to_s)}
 MSG
     elsif catched_exception
       "expected RSpec::Expectations::ExpectationNotMetError, but was #{catched_exception.inspect}"


### PR DESCRIPTION
These commits say WIP, but I think this may be good to go. I'm tempted to add another test that explores deep nesting of `with_text`, because I think that that somehow used to narrow the context correctly (which this PR is trying to fix for `with_tag`), but now doesn't.