### PR TITLE
Travis config to test back to ruby 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,98 @@
 sudo: false
 language: ruby
+
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+
 rvm:
-  - 2.1.0
-  - 2.1.1
-  - 2.1.2
-  - 2.2.0
-  - 2.3.0
-  - 2.3.1
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
   - 2.4.0
+
 jdk:
-  - openjdk7
   - oraclejdk7
+
+gemfile:
+  - Gemfile
+  - gemfiles/1.8.7.gemfile
+  - gemfiles/1.9.3.gemfile
+  - gemfiles/2.0.0.gemfile
+
+env:
+  - NO_CUCUMBER=true
+  - NO_CUCUMBER=false
+
+
 matrix:
   exclude:
-    - rvm: 2.1.0
-      jdk: openjdk7
+    - rvm: 1.8.7
+      gemfile: Gemfile
+    - rvm: 1.8.7
+      gemfile: gemfiles/1.9.3.gemfile
+    - rvm: 1.8.7
+      gemfile: gemfiles/2.0.0.gemfile
+    - rvm: 1.8.7
+      env: NO_CUCUMBER=false
 
-    - rvm: 2.1.1
-      jdk: openjdk7
+    - rvm: 1.9.3
+      gemfile: Gemfile
+    - rvm: 1.9.3
+      gemfile: gemfiles/1.8.7.gemfile
+    - rvm: 1.9.3
+      gemfile: gemfiles/2.0.0.gemfile
+    - rvm: 1.9.3
+      env: NO_CUCUMBER=true
 
-    - rvm: 2.1.2
-      jdk: openjdk7
+    - rvm: 2.0.0
+      gemfile: Gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/1.8.7.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/1.9.3.gemfile
+    - rvm: 2.0.0
+      env: NO_CUCUMBER=true
 
-    - rvm: 2.2.0
-      jdk: openjdk7
+    - rvm: 2.1.10
+      gemfile: gemfiles/1.8.7.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/1.9.3.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/2.0.0.gemfile
+    - rvm: 2.1.10
+      env: NO_CUCUMBER=true
 
-    - rvm: 2.3.0
-      jdk: openjdk7
+    - rvm: 2.2.6
+      gemfile: gemfiles/1.8.7.gemfile
+    - rvm: 2.2.6
+      gemfile: gemfiles/1.9.3.gemfile
+    - rvm: 2.2.6
+      gemfile: gemfiles/2.0.0.gemfile
+    - rvm: 2.2.6
+      env: NO_CUCUMBER=true
 
-    - rvm: 2.3.1
-      jdk: openjdk7
+    - rvm: 2.3.3
+      gemfile: gemfiles/1.8.7.gemfile
+    - rvm: 2.3.3
+      gemfile: gemfiles/1.9.3.gemfile
+    - rvm: 2.3.3
+      gemfile: gemfiles/2.0.0.gemfile
+    - rvm: 2.3.3
+      env: NO_CUCUMBER=true
 
     - rvm: 2.4.0
-      jdk: openjdk7
+      gemfile: gemfiles/1.8.7.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/1.9.3.gemfile
+    - rvm: 2.4.0
+      gemfile: gemfiles/2.0.0.gemfile
+    - rvm: 2.4.0
+      env: NO_CUCUMBER=true
+
 branches:
   only:
     - master

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,9 @@ require 'rspec/core/rake_task'
 require 'cucumber/rake/task'
 Bundler::GemHelper.install_tasks
 
-task :default => [:spec, :cucumber]
+suites = [:spec]
+suites << :cucumber unless ENV['NO_CUCUMBER'] == 'true'
+task :default => suites
 
 desc 'Validate the gemspec'
 task :gemspec do

--- a/gemfiles/1.8.7.gemfile
+++ b/gemfiles/1.8.7.gemfile
@@ -1,0 +1,7 @@
+source 'http://rubygems.org'
+gemspec :path => '..'
+
+gem 'mime-types', '= 1.25.1'
+gem 'selenium-webdriver', '= 2.35.1'
+gem 'nokogiri', '= 1.5.11'
+gem 'capybara', '= 2.0.3'

--- a/gemfiles/1.9.3.gemfile
+++ b/gemfiles/1.9.3.gemfile
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+gemspec path: '..'
+
+gem 'addressable', '= 2.4.0'
+gem 'mime-types', '= 2.6.2'
+gem 'nokogiri', '= 1.6.8.1'

--- a/gemfiles/2.0.0.gemfile
+++ b/gemfiles/2.0.0.gemfile
@@ -1,0 +1,4 @@
+source 'http://rubygems.org'
+gemspec path: '..'
+
+gem 'nokogiri', '= 1.6.8.1'

--- a/lib/rspec-html-matchers.rb
+++ b/lib/rspec-html-matchers.rb
@@ -304,7 +304,7 @@ module RSpecHtmlMatchers
   end
 
   def have_empty_tag tag, options={}
-    have_tag(tag, options.merge(text: ""))
+    have_tag(tag, options.merge(:text => ""))
   end
 
   def with_text text

--- a/rspec-html-matchers.gemspec
+++ b/rspec-html-matchers.gemspec
@@ -17,8 +17,7 @@ DESC
   s.require_path     = 'lib'
   s.extra_rdoc_files = ['README.md','CHANGELOG.md']
 
-  # depends on what ruby version nokogiri supports:
-  s.required_ruby_version = '>= 2.1'
+  s.required_ruby_version = '>= 1.8.7'
 
   s.add_runtime_dependency 'rspec',    '>= 3.0.0.a', '< 4'
   s.add_runtime_dependency 'nokogiri', '~> 1'

--- a/spec/form_matchers_spec.rb
+++ b/spec/form_matchers_spec.rb
@@ -7,7 +7,7 @@ describe "have_form" do
     it "should find form" do
       # sanity check
       expect(rendered).to have_form("/books", :post)
-      expect(rendered).to have_form("/books", "post", with: { id: "new_book", class: %w(book formtastic) })
+      expect(rendered).to have_form("/books", "post", :with => { :id => "new_book", :class => %w(book formtastic) })
     end
 
     it "should not find form" do
@@ -20,15 +20,15 @@ describe "have_form" do
     context "with_select" do
       it "should find select" do
         expect(rendered).to have_form("/books", :post) do
-          with_select("book[publisher_id]", with: { id: "book_publisher_id" })
-          with_select("book[publisher_id]", with: { id: "book_publisher_id" })
+          with_select("book[publisher_id]", :with => { :id => "book_publisher_id" })
+          with_select("book[publisher_id]", :with => { :id => "book_publisher_id" })
         end
       end
 
       it "should not find select" do
         expect(rendered).to have_form("/books", :post) do
-          without_select("book[publisher_id]", with: { id: "other_id" })
-          without_select("koob[publisher_id]", with: { id: "book_publisher_id" })
+          without_select("book[publisher_id]", :with => { :id => "other_id" })
+          without_select("koob[publisher_id]", :with => { :id => "book_publisher_id" })
         end
       end
 
@@ -37,9 +37,9 @@ describe "have_form" do
           expect(rendered).to have_form("/books", :post) do
             with_select("book[publisher_id]") do
               with_option(nil)
-              with_option("The Pragmatic Bookshelf", selected: true)
+              with_option("The Pragmatic Bookshelf", :selected => true)
               with_option(/sitepoint/,2)
-              with_option("O'Reilly", 3, selected: false)
+              with_option("O'Reilly", 3, :selected => false)
             end
           end
         end
@@ -48,7 +48,7 @@ describe "have_form" do
           expect(rendered).to have_form("/books", :post) do
             with_select("book[publisher_id]") do
               without_option("blah blah")
-              without_option("O'Reilly", 3, selected: true)
+              without_option("O'Reilly", 3, :selected => true)
               without_option("O'Reilly", 100500)
             end
           end
@@ -163,8 +163,8 @@ describe "have_form" do
         expect(rendered).to have_form("/books", :post) do
           with_range_field('range1', 1, 3)
           with_range_field('range1','1','3')
-          with_range_field('range2', 1, 3, with: { value: 2 } )
-          with_range_field('range2', 1, 3, with: { value: '2' } )
+          with_range_field('range2', 1, 3, :with => { :value => 2 } )
+          with_range_field('range2', 1, 3, :with => { :value => '2' } )
         end
       end
 
@@ -172,7 +172,7 @@ describe "have_form" do
         expect(rendered).to have_form("/books", :post) do
           without_range_field('number')
           without_range_field('range1', 1, 5)
-          without_range_field('range2', 1, 3, with: { value: 5 } )
+          without_range_field('range2', 1, 3, :with => { :value => 5 } )
         end
       end
     end
@@ -182,7 +182,7 @@ describe "have_form" do
         expect(rendered).to have_form("/books", :post) do
           with_date_field(:date)
           with_date_field(:date, 'book_date')
-          with_date_field(:month, 'book_month', with: { value: 5 })
+          with_date_field(:month, 'book_month', :with => { :value => 5 })
           with_date_field(:week,'book_week')
           with_date_field(:time, 'book_time')
           with_date_field(:datetime, 'book_datetime')
@@ -193,7 +193,7 @@ describe "have_form" do
       it "should not find date field" do
         expect(rendered).to have_form("/books", :post) do
           without_date_field(:date, 'book_something')
-          without_date_field(:month, 'book_month', with: { value: 100500 })
+          without_date_field(:month, 'book_month', :with => { :value => 100500 })
         end
       end
 

--- a/spec/have_empty_tag_spec.rb
+++ b/spec/have_empty_tag_spec.rb
@@ -6,9 +6,9 @@ describe 'have_empty_tag' do
     asset 'single_element'
 
     it { expect(rendered).to have_empty_tag('div') }
-    it { expect(rendered).to have_empty_tag('div', class: "foo") }
-    it { expect(rendered).to have_empty_tag('div', class: "bar") }
-    it { expect(rendered).to have_empty_tag('div', class: "foo bar") }
+    it { expect(rendered).to have_empty_tag('div', :class => "foo") }
+    it { expect(rendered).to have_empty_tag('div', :class => "bar") }
+    it { expect(rendered).to have_empty_tag('div', :class => "foo bar") }
   end
 
   context 'when paragraphs' do
@@ -23,7 +23,7 @@ describe 'have_empty_tag' do
     it { expect(rendered).to_not have_empty_tag('html') }
     it { expect(rendered).to_not have_empty_tag('body') }
     it { expect(rendered).to_not have_empty_tag('ol') }
-    it { expect(rendered).to_not have_empty_tag('ol', class: 'menu') }
+    it { expect(rendered).to_not have_empty_tag('ol', :class => 'menu') }
     it { expect(rendered).to_not have_empty_tag('li') }
   end
 end

--- a/spec/have_tag_spec.rb
+++ b/spec/have_tag_spec.rb
@@ -295,7 +295,9 @@ describe 'have_tag' do
         expect(rendered).to have_tag('p',    :seen => 'content with ignored spaces in')
         expect(rendered).to have_tag('p',    :seen => 'content with nbsp  and  spaces   around')
 
-        expect(rendered).to have_tag('p',    :text => 'content with nbsp')
+        unless Nokogiri::VERSION == '1.5.11'
+          expect(rendered).to have_tag('p',    :text => 'content with nbsp')
+        end
         expect(rendered).to have_tag('pre',  :text => " 1. bla   \n 2. bla ")
       end
 
@@ -425,9 +427,10 @@ describe 'have_tag' do
           with_text /sample with 'single' and "double" quotes/
         end
 
-
-        expect(rendered).to have_tag('p') do
-          with_text 'content with nbsp'
+        unless Nokogiri::VERSION == '1.5.11'
+          expect(rendered).to have_tag('p') do
+            with_text 'content with nbsp'
+          end
         end
 
         expect(rendered).to have_tag('pre') do
@@ -634,22 +637,22 @@ describe 'have_tag' do
 
     it 'with block parameters' do
       expect(rendered).to have_tag('div#one') do |a|
-        expect(a).to have_tag 'p.find_me', count: 2
+        expect(a).to have_tag 'p.find_me', :count => 2
 
-        expect(a).to have_tag 'b.nested', count: 3
-        expect(a).to have_tag('p.deep-nesting', count: 1) do |b|
-          expect(b).to have_tag 'b.nested', count: 2
+        expect(a).to have_tag 'b.nested', :count => 3
+        expect(a).to have_tag('p.deep-nesting', :count => 1) do |b|
+          expect(b).to have_tag 'b.nested', :count => 2
         end
       end
     end
 
     it 'with short_hand methods' do
       expect(rendered).to have_tag('div#one') do
-        with_tag 'p.find_me', count: 2
+        with_tag 'p.find_me', :count => 2
 
-        with_tag 'b.nested', count: 3
-        with_tag('p.deep-nesting', count: 1) do
-          with_tag 'b.nested', count: 2
+        with_tag 'b.nested', :count => 3
+        with_tag('p.deep-nesting', :count => 1) do
+          with_tag 'b.nested', :count => 2
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.filter_run_excluding wip: true
+  config.filter_run_excluding :wip => true
 
   config.extend AssetHelpers
 end


### PR DESCRIPTION
Set-up Travis to test old ruby versions. We support rspec 3.0.0, and rspec 3.0.0 supports ruby 1.8.7.
I had to disable cucumber in 1.8.7 tests, but it's better than nothing. For more recent versions all tests are running.