### PR TITLE
Allow matching on XML document

### DIFF
--- a/lib/rspec-html-matchers/have_tag.rb
+++ b/lib/rspec-html-matchers/have_tag.rb
@@ -73,7 +73,7 @@ module RSpecHtmlMatchers
 
       case document
         when String
-          @parent_scope = Nokogiri::HTML(document)
+          @parent_scope = nokogiri_parse(document)
           @document     = document
         else
           @parent_scope  = document.current_scope
@@ -108,6 +108,10 @@ module RSpecHtmlMatchers
     end
 
     private
+
+    def nokogiri_parse(document)
+      @options[:xml] ? Nokogiri::XML(document) : Nokogiri::HTML(document)
+    end
 
     def classes_to_selector(classes)
       case classes

--- a/spec/fixtures/xml.html
+++ b/spec/fixtures/xml.html
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<MYTAG MsgType="MYmsg">
+  <LocalTime>163005</LocalTime>
+  <LocalDate>1224</LocalDate>
+</MYTAG>

--- a/spec/have_tag_spec.rb
+++ b/spec/have_tag_spec.rb
@@ -681,4 +681,22 @@ describe 'have_tag' do
     end
   end
 
+  context "for xml" do
+    asset "xml"
+
+    it "should find tags" do
+      expect(rendered).to have_tag('MYTAG', xml: true)
+      expect(rendered).to have_tag(:MYTAG, xml: true)
+      expect(rendered).to have_tag('MYTAG[MsgType=MYmsg]', xml: true)
+      expect(rendered).to have_tag('MYTAG LocalTime', xml: true)
+    end
+
+    it "should not find tags" do
+      expect(rendered).to_not have_tag('MYTAG2')
+      expect(rendered).to_not have_tag(:span)
+      expect(rendered).to_not have_tag('MYTAG#id')
+      expect(rendered).to_not have_tag('MYTAG#class')
+      expect(rendered).to_not have_tag('MYTAG OtherTime')
+    end
+  end
 end

--- a/spec/have_tag_spec.rb
+++ b/spec/have_tag_spec.rb
@@ -685,10 +685,10 @@ describe 'have_tag' do
     asset "xml"
 
     it "should find tags" do
-      expect(rendered).to have_tag('MYTAG', xml: true)
-      expect(rendered).to have_tag(:MYTAG, xml: true)
-      expect(rendered).to have_tag('MYTAG[MsgType=MYmsg]', xml: true)
-      expect(rendered).to have_tag('MYTAG LocalTime', xml: true)
+      expect(rendered).to have_tag('MYTAG', :xml => true)
+      expect(rendered).to have_tag(:MYTAG, :xml => true)
+      expect(rendered).to have_tag('MYTAG[MsgType=MYmsg]', :xml => true)
+      expect(rendered).to have_tag('MYTAG LocalTime', :xml => true)
     end
 
     it "should not find tags" do


### PR DESCRIPTION
Extends the ```have_tag``` matcher with the ```xml``` parameter, which switches to using the nokogiri XML parser.