### PR TITLE
ruby 2.6.5 in test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
 
 rvm:
-  - 1.8.7
+  - 1.8.7-head
   - 1.9.3
   - 2.0.0
   - 2.1.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,6 @@ before_script:
 services:
   - xvfb
 rvm:
-  - 1.8.7-head
-  - 1.9.3
-  - 2.0.0
-  - 2.1.10
-  - 2.2.6
-  - 2.3.3
   - 2.4.0
   - 2.6.5
 
@@ -20,9 +14,6 @@ jdk:
 
 gemfile:
   - Gemfile
-  - gemfiles/1.8.7.gemfile
-  - gemfiles/1.9.3.gemfile
-  - gemfiles/2.0.0.gemfile
 
 env:
   - NO_CUCUMBER=true
@@ -31,75 +22,9 @@ env:
 
 matrix:
   exclude:
-    - rvm: 1.8.7
-      gemfile: Gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/1.9.3.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/2.0.0.gemfile
-    - rvm: 1.8.7
-      env: NO_CUCUMBER=false
-
-    - rvm: 1.9.3
-      gemfile: Gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/1.8.7.gemfile
-    - rvm: 1.9.3
-      gemfile: gemfiles/2.0.0.gemfile
-    - rvm: 1.9.3
-      env: NO_CUCUMBER=true
-
-    - rvm: 2.0.0
-      gemfile: Gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/1.8.7.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/1.9.3.gemfile
-    - rvm: 2.0.0
-      env: NO_CUCUMBER=true
-
-    - rvm: 2.1.10
-      gemfile: gemfiles/1.8.7.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/1.9.3.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/2.0.0.gemfile
-    - rvm: 2.1.10
-      env: NO_CUCUMBER=true
-
-    - rvm: 2.2.6
-      gemfile: gemfiles/1.8.7.gemfile
-    - rvm: 2.2.6
-      gemfile: gemfiles/1.9.3.gemfile
-    - rvm: 2.2.6
-      gemfile: gemfiles/2.0.0.gemfile
-    - rvm: 2.2.6
-      env: NO_CUCUMBER=true
-
-    - rvm: 2.3.3
-      gemfile: gemfiles/1.8.7.gemfile
-    - rvm: 2.3.3
-      gemfile: gemfiles/1.9.3.gemfile
-    - rvm: 2.3.3
-      gemfile: gemfiles/2.0.0.gemfile
-    - rvm: 2.3.3
-      env: NO_CUCUMBER=true
-
-    - rvm: 2.4.0
-      gemfile: gemfiles/1.8.7.gemfile
-    - rvm: 2.4.0
-      gemfile: gemfiles/1.9.3.gemfile
-    - rvm: 2.4.0
-      gemfile: gemfiles/2.0.0.gemfile
     - rvm: 2.4.0
       env: NO_CUCUMBER=true
 
-    - rvm: 2.6.5
-      gemfile: gemfiles/1.8.7.gemfile
-    - rvm: 2.6.5
-      gemfile: gemfiles/1.9.3.gemfile
-    - rvm: 2.6.5
-      gemfile: gemfiles/2.0.0.gemfile
     - rvm: 2.6.5
       env: NO_CUCUMBER=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: ruby
 
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-
+  - export DISPLAY=:99.0
+services:
+  - xvfb
 rvm:
   - 1.8.7-head
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
   - 2.2.6
   - 2.3.3
   - 2.4.0
+  - 2.6.5
 
 jdk:
   - oraclejdk7
@@ -22,6 +23,7 @@ gemfile:
   - gemfiles/1.8.7.gemfile
   - gemfiles/1.9.3.gemfile
   - gemfiles/2.0.0.gemfile
+  - gemfiles/2.6.0.gemfile
 
 env:
   - NO_CUCUMBER=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,13 @@ rvm:
   - 2.6.5
 
 jdk:
-  - oraclejdk7
+  - oraclejdk9
 
 gemfile:
   - Gemfile
   - gemfiles/1.8.7.gemfile
   - gemfiles/1.9.3.gemfile
   - gemfiles/2.0.0.gemfile
-  - gemfiles/2.6.0.gemfile
 
 env:
   - NO_CUCUMBER=true
@@ -93,6 +92,15 @@ matrix:
     - rvm: 2.4.0
       gemfile: gemfiles/2.0.0.gemfile
     - rvm: 2.4.0
+      env: NO_CUCUMBER=true
+
+    - rvm: 2.6.5
+      gemfile: gemfiles/1.8.7.gemfile
+    - rvm: 2.6.5
+      gemfile: gemfiles/1.9.3.gemfile
+    - rvm: 2.6.5
+      gemfile: gemfiles/2.0.0.gemfile
+    - rvm: 2.6.5
       env: NO_CUCUMBER=true
 
 branches:

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,7 @@ World(RSpec::Matchers)
 require 'sinatra/base'
 require 'capybara/cucumber'
 require 'rspec-html-matchers'
+require 'webdrivers'
 
 World RSpecHtmlMatchers
 
@@ -14,7 +15,20 @@ class SimpleApp < Sinatra::Base
   set :public_folder, $ASSETS_DIR
 end
 
-Capybara.default_driver = :selenium
+Capybara.register_driver :headless_chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless')
+  options.add_argument('--disable-gpu')
+  options.add_argument('--window-size=800,600')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.configure do |config|
+  config.default_max_wait_time = 15
+  config.default_driver = :headless_chrome
+end
+# Capybara.default_driver = :selenium
 Capybara.app = SimpleApp
 
 Before do

--- a/gemfiles/2.6.0.gemfile
+++ b/gemfiles/2.6.0.gemfile
@@ -1,0 +1,4 @@
+source 'http://rubygems.org'
+gemspec path: '..'
+
+gem 'nokogiri', '= 1.10.4'

--- a/gemfiles/2.6.0.gemfile
+++ b/gemfiles/2.6.0.gemfile
@@ -1,4 +1,0 @@
-source 'http://rubygems.org'
-gemspec path: '..'
-
-gem 'nokogiri', '= 1.10.4'

--- a/rspec-html-matchers.gemspec
+++ b/rspec-html-matchers.gemspec
@@ -30,9 +30,10 @@ DESC
   s.add_development_dependency 'simplecov',          '~> 0'
   s.add_development_dependency 'cucumber',           '~> 1'
   s.add_development_dependency 'capybara',           '~> 2'
-  s.add_development_dependency 'selenium-webdriver', '~> 2'
+  s.add_development_dependency 'selenium-webdriver', '~> 3'
   s.add_development_dependency 'sinatra',            '~> 1'
   s.add_development_dependency 'rake',               '~> 10'
   s.add_development_dependency 'travis-lint',        '~> 1'
   s.add_development_dependency 'yard'
+  s.add_development_dependency 'webdrivers'
 end


### PR DESCRIPTION
add ruby 2.6.5 (latest version) to test matrix.
- remove ruby < 2.4.0 those are not supported
- use webdrivers in cucumber test
- openjdk7 is not supported now, so changed to openjdk9