### PR TITLE
Restore the support for matching `html` and `body`

### DIFF
--- a/lib/rspec-html-matchers/have_tag.rb
+++ b/lib/rspec-html-matchers/have_tag.rb
@@ -79,7 +79,7 @@ module RSpecHtmlMatchers
 
       case src
       when String
-        parent_scope = Nokogiri::HTML::DocumentFragment.parse(src)
+        parent_scope = Nokogiri::HTML(src)
         @document    = src
       else
         parent_scope  = src.current_scope

--- a/spec/fixtures/document.html
+++ b/spec/fixtures/document.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    test
+  </body>
+</html>

--- a/spec/have_tag_spec.rb
+++ b/spec/have_tag_spec.rb
@@ -669,4 +669,16 @@ describe 'have_tag' do
       end
     end
   end
+
+  context 'html and body elements' do
+    asset 'document'
+
+    it 'should find the html element' do
+      expect(rendered).to have_tag('html')
+    end
+
+    it 'should find the body element' do
+      expect(rendered).to have_tag('body')
+    end
+  end
 end

--- a/spec/issues_spec.rb
+++ b/spec/issues_spec.rb
@@ -4,16 +4,6 @@
 require 'spec_helper'
 
 describe 'working on github issues' do
-  describe '#62' do # https://github.com/kucaahbe/rspec-html-matchers/issues/62
-    it 'should not have html tag' do
-      expect('<p>My paragraph.</p>').not_to have_tag('html')
-    end
-
-    it 'should not have body tag' do
-      expect('<p>My paragraph.</p>').not_to have_tag('body')
-    end
-  end
-
   it '#73' do # https://github.com/kucaahbe/rspec-html-matchers/issues/73
     rendered = <<HTML
       <p>


### PR DESCRIPTION
This effectively reverts 306b8f41ba73280379bc1c6c88c615097a4091ce and adds specs for matching `html` and `body` elements.

The issue reported in #62 isn't solvable using DOM assertions. DOM tree has to have a root element (`html`). Using `DocumentFragment` extracts a part of the tree, so it won't contain `html` or `body` elements, but that doesn't mean they weren't a part of the input.