### PR TITLE
Mark as compatible with RSpec 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rspec-html-matchers [![Gem Version](https://badge.fury.io/rb/rspec-html-matchers.svg)](https://badge.fury.io/rb/rspec-html-matchers) [![Build Status](https://travis-ci.com/kucaahbe/rspec-html-matchers.svg?branch=master)](https://travis-ci.com/kucaahbe/rspec-html-matchers)
 
-[RSpec 3](https://www.relishapp.com/rspec) matchers for testing your html (for [RSpec 2](https://www.relishapp.com/rspec/rspec-core/v/2-99/docs) use 0.5.x version).
+[RSpec 3 & 4](https://www.relishapp.com/rspec) matchers for testing your html (for [RSpec 2](https://www.relishapp.com/rspec/rspec-core/v/2-99/docs) use 0.5.x version).
 
 Goals
 -----

--- a/rspec-html-matchers.gemspec
+++ b/rspec-html-matchers.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.email       = ['kucaahbe@ukr.net', 'randoum@gmail.com']
   s.license     = 'MIT'
   s.homepage    = 'https://github.com/kucaahbe/rspec-html-matchers'
-  s.summary     = "Nokogiri based 'have_tag' and 'with_tag' matchers for rspec 3"
+  s.summary     = "Nokogiri based 'have_tag' and 'with_tag' matchers for rspec 3 & 4"
   s.description = <<DESC
 #{s.summary}. Does not depend on assert_select matcher, provides useful error messages.
 DESC
@@ -28,7 +28,7 @@ DESC
   # ruby support is tied to rspec & nokogiri gems:
   s.required_ruby_version = '>= 1.8.7'
 
-  s.add_runtime_dependency 'rspec',    '>= 3.0.0.a', '< 4'
+  s.add_runtime_dependency 'rspec',    '>= 3.0.0.a', '< 5'
   s.add_runtime_dependency 'nokogiri', '~> 1'
 
   # cucumber tests:


### PR DESCRIPTION
Because apparently it is, see https://github.com/pirj/discourse/pull/1/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR175 according to the green build:

https://github.com/pirj/discourse/runs/7507041034?check_suite_focus=true