### PR TITLE
Add have_child_tag to match any child or grand child tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+**NOTE**: the master branch has been deprecated, for latest docs and stuff use [main](https://github.com/kucaahbe/rspec-html-matchers/blob/main/CHANGELOG.md) branch instead
+
 0.10.0
 ------
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![RSpec JRuby](https://github.com/kucaahbe/rspec-html-matchers/actions/workflows/rspec-jruby.yml/badge.svg)](https://github.com/kucaahbe/rspec-html-matchers/actions/workflows/rspec-jruby.yml)
 [![Cucumber MRI](https://github.com/kucaahbe/rspec-html-matchers/actions/workflows/cucumber-mri.yml/badge.svg)](https://github.com/kucaahbe/rspec-html-matchers/actions/workflows/cucumber-mri.yml)
 
+**NOTE**: the master branch has been deprecated, for latest docs and stuff use main branch instead
+
 Goals
 -----
 

--- a/lib/rspec-html-matchers.rb
+++ b/lib/rspec-html-matchers.rb
@@ -65,6 +65,11 @@ module RSpecHtmlMatchers
     @__current_scope_for_nokogiri_matcher = HaveTag.new(tag, options, &block)
   end
 
+  def have_child_tag tag, options = {}, &block
+    options[:match_any_child_tag] = true
+    have_tag(tag, options, &block)
+  end
+
   # tests whether tag have any content inside
   #
   # @example

--- a/lib/rspec-html-matchers/have_tag.rb
+++ b/lib/rspec-html-matchers/have_tag.rb
@@ -44,6 +44,7 @@ module RSpecHtmlMatchers
 
     def initialize tag, options = {}, &block
       @tag = tag.to_s
+      @match_any_child_tag = options.delete(:match_any_child_tag)
       @options = options
       @block = block
 
@@ -60,6 +61,10 @@ module RSpecHtmlMatchers
 
       if (without_attrs = @options.delete(:without)) && classes = without_attrs.delete(:class)
         @tag += ":not(.#{classes_to_selector(classes)})"
+      end
+
+      if @match_any_child_tag
+        @tag = "* > #{@tag}"
       end
 
       validate_options!
@@ -89,6 +94,7 @@ module RSpecHtmlMatchers
       rescue NoMethodError
         Nokogiri::XML::NodeSet.new(Nokogiri::XML::Document.new)
       end
+
       if tag_presents? && proper_content? && count_right?
         @block.call(self) if @block
         true

--- a/spec/fixtures/nested_matchers.html
+++ b/spec/fixtures/nested_matchers.html
@@ -4,7 +4,9 @@
 
     <b class="nested"></b>
     <p class="deep-nesting">
-        <b class="nested"></b>
+        <b class="nested">
+          <i>italic</i>
+        </b>
         <b class="nested"></b>
     </p>
 </div>

--- a/spec/have_tag_spec.rb
+++ b/spec/have_tag_spec.rb
@@ -3,6 +3,52 @@
 
 require 'spec_helper'
 
+describe 'have_child_tag' do
+  asset 'nested_matchers'
+
+  it 'should not find itself' do
+    expect(rendered).to have_tag('div#one') do |a|
+      expect(a).not_to have_child_tag 'div#one'
+    end
+  end
+
+  it 'should not find siblings tags' do
+    expect(rendered).to have_tag('div#one') do |a|
+      expect(a).not_to have_child_tag 'div#two'
+    end
+    expect(rendered).to have_tag('p.find_me', :count => 3) do |b|
+      expect(b).not_to have_child_tag 'p.find_me'
+    end
+  end
+
+  it 'should not find siblings tags' do
+    expect(rendered).to have_tag('div#one') do |a|
+      expect(a).not_to have_child_tag 'div#two'
+
+      expect(a).to have_tag('p.deep-nesting', :count => 1) do |b|
+        expect(b).not_to have_child_tag 'div#one'
+        expect(b).not_to have_child_tag 'p.find_me'
+        expect(b).to have_child_tag 'b.nested'
+      end
+    end
+  end
+
+  it 'should find direct children' do
+    expect(rendered).to have_tag('div#one') do |a|
+      expect(a).to have_child_tag 'p.find_me'
+      expect(a).to have_child_tag('p.deep-nesting', :count => 1)
+    end
+  end
+
+  it 'should find grand children at any level' do
+    expect(rendered).to have_tag('div#one') do |a|
+      expect(a).to have_child_tag 'p.find_me'
+      expect(a).to have_child_tag('p.deep-nesting', :count => 1)
+      expect(a).to have_child_tag('i', :count => 1)
+    end
+  end
+end
+
 describe 'have_tag' do
   context '[through css selector]' do
     asset 'search_and_submit'


### PR DESCRIPTION
* The `have_child_tag` can be used to match any child or grand child tags.
* Does not alter any existing matchers' behaviour.

TODO: Documentation pending.